### PR TITLE
fix: no cuda memory management if on CPU

### DIFF
--- a/run_permgwas.py
+++ b/run_permgwas.py
@@ -99,8 +99,9 @@ if __name__ == "__main__":
                        'effect_size': output[:, 3]})
     print('Done performing GWAS on phenotype %s for %d SNPs.\n '
           'Elapsed time: %f s' % (args.y_name, len(positions), time.time()-start_gwas))
-    with torch.cuda.device(args.device):
-        torch.cuda.empty_cache()
+    if arguments.device.type != "cpu":
+        with torch.cuda.device(args.device):
+            torch.cuda.empty_cache()
 
     '''perform GWAS with permutations'''
     if args.perm is not None:


### PR DESCRIPTION
Running the example command on a machine without GPU leads to the following error:
```
$ python3 run_permgwas.py -x ./data/x_matrix.h5 -y ./data/y_matrix.csv
GPU is not available. Perform computations on device  cpu
Checked if all specified files exist. Start loading data.
Loaded data, elapsed time: 0.676957 s.
Start performing GWAS on phenotype phenotype_value for 50000 SNPs and 194 samples.
Traceback (most recent call last):
  File "run_permgwas.py", line 92, in <module>
    output = gwas.gwas(args, X, y, K, covs)
  File "/home/s216121/software/permGWAS/perform_gwas/gwas.py", line 46, in gwas
    with torch.cuda.device(arguments.device):
  File "/usr/local/lib/python3.8/dist-packages/torch/cuda/__init__.py", line 266, in __init__
    self.idx = _get_device_index(device, optional=True)
  File "/usr/local/lib/python3.8/dist-packages/torch/cuda/_utils.py", line 30, in _get_device_index
    raise ValueError('Expected a cuda device, but got: {}'.format(device))
ValueError: Expected a cuda device, but got: cpu
```

Making the CUDA memory management code conditional on not being on the CPU solves the issue.