### PR TITLE
Fix typo

### DIFF
--- a/run_permgwas.py
+++ b/run_permgwas.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
                        'effect_size': output[:, 3]})
     print('Done performing GWAS on phenotype %s for %d SNPs.\n '
           'Elapsed time: %f s' % (args.y_name, len(positions), time.time()-start_gwas))
-    if arguments.device.type != "cpu":
+    if args.device.type != "cpu":
         with torch.cuda.device(args.device):
             torch.cuda.empty_cache()
 


### PR DESCRIPTION
I mistyped `args` as `arguments`